### PR TITLE
Add playwright tests for TodoMVC app

### DIFF
--- a/playwright/tests/pages/TodoPage.js
+++ b/playwright/tests/pages/TodoPage.js
@@ -9,10 +9,16 @@ class TodoPage {
         this.todoItemLabels = this.todoItems.getByTestId('todo-item-label');
         this.todoItemCheckbox = this.todoItems.getByTestId('todo-item-toggle');
         this.todoDelete = page.getByTestId('todo-item-button');
+        this.clearCompletedButton = page.getByText('Clear completed');
+        this.todoCountSummary = page.getByTestId('footer').locator('.todo-count');
     }
 
     async goto() {
         await this.page.goto('https://todomvc.com/examples/react/dist/');
+    }
+
+    async clearCompletedTodoItems() {
+        await this.clearCompletedButton.click();
     }
 
     async switchListTo(text) {
@@ -26,7 +32,6 @@ class TodoPage {
 
     async editTodoItem(text, newText) {
         const index = await this.findItemIndex(text);
-        console.log(`index: ${index}`)
         if (index >= 0) await this.editTodoItemByIndex(index, newText);
         return this;
     }

--- a/playwright/tests/pages/TodoPage.js
+++ b/playwright/tests/pages/TodoPage.js
@@ -5,6 +5,7 @@ class TodoPage {
         this.page = page;
         this.newTodoInput = page.getByTestId('header').getByTestId('text-input');
         this.todoItems = page.getByTestId('todo-list').locator('li');
+        this.completedTodoItems = page.locator('.completed').locator('li');
         this.todoItemInput = this.todoItems.getByTestId('text-input');
         this.todoItemLabels = this.todoItems.getByTestId('todo-item-label');
         this.todoItemCheckbox = this.todoItems.getByTestId('todo-item-toggle');

--- a/playwright/tests/pages/TodoPage.js
+++ b/playwright/tests/pages/TodoPage.js
@@ -5,7 +5,7 @@ class TodoPage {
         this.page = page;
         this.newTodoInput = page.getByTestId('header').getByTestId('text-input');
         this.todoItems = page.getByTestId('todo-list').locator('li');
-        this.completedTodoItems = page.locator('.completed').locator('li');
+        this.completedTodoItems = page.locator('.completed');
         this.todoItemInput = this.todoItems.getByTestId('text-input');
         this.todoItemLabels = this.todoItems.getByTestId('todo-item-label');
         this.todoItemCheckbox = this.todoItems.getByTestId('todo-item-toggle');
@@ -35,6 +35,14 @@ class TodoPage {
         const index = await this.findItemIndex(text);
         if (index >= 0) await this.editTodoItemByIndex(index, newText);
         return this;
+    }
+
+    getTodoItem(text) {
+        return this.todoItems.getByText(text);
+    }
+
+    getCompletedTodoItem(text) {
+        return this.completedTodoItems.getByText(text);
     }
 
     async findItemIndex(text) {
@@ -83,7 +91,7 @@ class TodoPage {
     */
 
     async todoItemCount() {
-        return this.todoItemLabels.count();
+        return await this.todoItemLabels.count();
     }
 }
 

--- a/playwright/tests/pages/TodoPage.js
+++ b/playwright/tests/pages/TodoPage.js
@@ -4,7 +4,7 @@ class TodoPage {
     constructor(page) {
         this.page = page;
         this.newTodoInput = page.getByTestId('header').getByTestId('text-input');
-        this.todoItems = page.getByTestId('todo-item');
+        this.todoItems = page.getByTestId('todo-list').locator('li');
         this.todoItemInput = this.todoItems.getByTestId('text-input');
         this.todoItemLabels = this.todoItems.getByTestId('todo-item-label');
         this.todoItemCheckbox = this.todoItems.getByTestId('todo-item-toggle');
@@ -13,6 +13,10 @@ class TodoPage {
 
     async goto() {
         await this.page.goto('https://todomvc.com/examples/react/dist/');
+    }
+
+    async switchListTo(text) {
+        await this.page.getByTestId('footer-navigation').getByText(text).click();
     }
 
     async addTodoItem(text) {

--- a/playwright/tests/pages/TodoPage.js
+++ b/playwright/tests/pages/TodoPage.js
@@ -4,13 +4,17 @@ class TodoPage {
     constructor(page) {
         this.page = page;
         this.newTodoInput = page.getByTestId('header').getByTestId('text-input');
+
         this.todoItems = page.getByTestId('todo-list').locator('li');
-        this.completedTodoItems = page.locator('.completed');
+        this.activeTodoItems = page.getByTestId('todo-list').locator('li:not(.completed)');
+        this.completedTodoItems = page.getByTestId('todo-list').locator('.completed');
+
         this.todoItemInput = this.todoItems.getByTestId('text-input');
         this.todoItemLabels = this.todoItems.getByTestId('todo-item-label');
         this.todoItemCheckbox = this.todoItems.getByTestId('todo-item-toggle');
         this.todoDelete = page.getByTestId('todo-item-button');
         this.clearCompletedButton = page.getByText('Clear completed');
+
         this.todoCountSummary = page.getByTestId('footer').locator('.todo-count');
     }
 
@@ -39,6 +43,10 @@ class TodoPage {
 
     getTodoItem(text) {
         return this.todoItems.getByText(text);
+    }
+
+    getActiveTodoItem(text) {
+        return this.activeTodoItems.getByText(text);
     }
 
     getCompletedTodoItem(text) {

--- a/playwright/tests/pages/TodoPage.js
+++ b/playwright/tests/pages/TodoPage.js
@@ -32,6 +32,7 @@ class TodoPage {
         return this;
     }
 
+    /*
     async deleteTodoByIndex(index) {
         await this.todoItems.nth(index).hover();
         await this.todoDelete.nth(index).waitFor({state: 'visible'});
@@ -39,6 +40,7 @@ class TodoPage {
         await this.todoDelete.nth(index).click();
         return this;
     }
+    */
 
     async markTodoComplete(text) { 
         const index = this.findItemIndex(text);
@@ -46,11 +48,13 @@ class TodoPage {
         return this;
     }
 
+    /*
     async deleteTodoItem(text) {
         const index = this.findItemIndex(text);
         if (index >= 0) await this.deleteTodoByIndex(index);
         return this;
     }
+    */
 
     async todoItemCount() {
         return this.todoItems.count();

--- a/playwright/tests/pages/TodoPage.js
+++ b/playwright/tests/pages/TodoPage.js
@@ -3,9 +3,11 @@ const { expect } = require('@playwright/test');
 class TodoPage {
     constructor(page) {
         this.page = page;
-        this.todoInput = page.getByTestId('text-input');
-        this.todoItems = page.getByTestId('todo-item-label');
-        this.todoCheckbox = page.getByTestId('todo-item-toggle');
+        this.newTodoInput = page.getByTestId('header').getByTestId('text-input');
+        this.todoItems = page.getByTestId('todo-item');
+        this.todoItemInput = this.todoItems.getByTestId('text-input');
+        this.todoItemLabels = this.todoItems.getByTestId('todo-item-label');
+        this.todoItemCheckbox = this.todoItems.getByTestId('todo-item-toggle');
         this.todoDelete = page.getByTestId('todo-item-button');
     }
 
@@ -13,28 +15,42 @@ class TodoPage {
         await this.page.goto('https://todomvc.com/examples/react/dist/');
     }
 
-    async addTodo(text) {
-        await this.todoInput.fill(text);
-        await this.todoInput.press('Enter');
+    async addTodoItem(text) {
+        await this.newTodoInput.fill(text);
+        await this.newTodoInput.press('Enter');
+    }
+
+    async editTodoItem(text, newText) {
+        const index = await this.findItemIndex(text);
+        console.log(`index: ${index}`)
+        if (index >= 0) await this.editTodoItemByIndex(index, newText);
+        return this;
     }
 
     async findItemIndex(text) {
-        for (let i=0; i < this.todoItemCount(); i++) {
-            const todoItemText = this.todoItems.nth(i).textContent;
+        for (let i=0; i < await this.todoItemCount(); i++) {
+            const todoItemText = await this.todoItemLabels.nth(i).textContent();
             if (todoItemText === text) return i;
         }
         // not found
         return -1;
     }
 
+    async editTodoItemByIndex(index, newText) {
+        await this.todoItemLabels.nth(index).dblclick();
+        await this.todoItemInput.nth(index).fill(newText);
+        await this.todoItemInput.nth(index).press('Enter');
+        return this;
+    }
+
     async markTodoCompleteByIndex(index) {
-        await this.todoCheckbox.nth(index).click();
+        await this.todoItemCheckbox.nth(index).click();
         return this;
     }
 
     /*
     async deleteTodoByIndex(index) {
-        await this.todoItems.nth(index).hover();
+        await this.todoItemLabels.nth(index).hover();
         await this.todoDelete.nth(index).waitFor({state: 'visible'});
         await expect(this.todoDelete.nth(index)).toBeVisible();
         await this.todoDelete.nth(index).click();
@@ -43,7 +59,7 @@ class TodoPage {
     */
 
     async markTodoComplete(text) { 
-        const index = this.findItemIndex(text);
+        const index = await this.findItemIndex(text);
         if (index >= 0) await this.markTodoCompleteByIndex(index);
         return this;
     }
@@ -57,7 +73,7 @@ class TodoPage {
     */
 
     async todoItemCount() {
-        return this.todoItems.count();
+        return this.todoItemLabels.count();
     }
 }
 

--- a/playwright/tests/pages/TodoPage.js
+++ b/playwright/tests/pages/TodoPage.js
@@ -1,0 +1,60 @@
+const { expect } = require('@playwright/test');
+
+class TodoPage {
+    constructor(page) {
+        this.page = page;
+        this.todoInput = page.getByTestId('text-input');
+        this.todoItems = page.getByTestId('todo-item-label');
+        this.todoCheckbox = page.getByTestId('todo-item-toggle');
+        this.todoDelete = page.getByTestId('todo-item-button');
+    }
+
+    async goto() {
+        await this.page.goto('https://todomvc.com/examples/react/dist/');
+    }
+
+    async addTodo(text) {
+        await this.todoInput.fill(text);
+        await this.todoInput.press('Enter');
+    }
+
+    async findItemIndex(text) {
+        for (let i=0; i < this.todoItemCount(); i++) {
+            const todoItemText = this.todoItems.nth(i).textContent;
+            if (todoItemText === text) return i;
+        }
+        // not found
+        return -1;
+    }
+
+    async markTodoCompleteByIndex(index) {
+        await this.todoCheckbox.nth(index).click();
+        return this;
+    }
+
+    async deleteTodoByIndex(index) {
+        await this.todoItems.nth(index).hover();
+        await this.todoDelete.nth(index).waitFor({state: 'visible'});
+        await expect(this.todoDelete.nth(index)).toBeVisible();
+        await this.todoDelete.nth(index).click();
+        return this;
+    }
+
+    async markTodoComplete(text) { 
+        const index = this.findItemIndex(text);
+        if (index >= 0) await this.markTodoCompleteByIndex(index);
+        return this;
+    }
+
+    async deleteTodoItem(text) {
+        const index = this.findItemIndex(text);
+        if (index >= 0) await this.deleteTodoByIndex(index);
+        return this;
+    }
+
+    async todoItemCount() {
+        return this.todoItems.count();
+    }
+}
+
+module.exports = TodoPage;

--- a/playwright/tests/todomvc.spec.js
+++ b/playwright/tests/todomvc.spec.js
@@ -19,7 +19,7 @@ test.describe('todo mvc', () => {
             await expect(todoPage.todoItems).toHaveCount(1);
         });
 
-        test.only('mark a todo as complete', async ({ page }) => {
+        test('mark a todo as complete', async ({ page }) => {
             await todoPage.addTodoItem('buy milk');
             await expect(todoPage.todoItems).toHaveCount(1);
 
@@ -78,6 +78,11 @@ test.describe('todo mvc', () => {
 
             await todoPage.markTodoComplete('buy eggs');
             await todoPage.markTodoComplete('buy butter');
+
+
+            await expect(todoPage.getActiveTodoItem('buy milk')).toHaveText('buy milk');
+            await expect(todoPage.getCompletedTodoItem('buy butter')).toHaveText('buy butter');
+            await expect(todoPage.getCompletedTodoItem('buy butter')).toHaveText('buy butter');
 
             await todoPage.clearCompletedTodoItems();
             await expect(todoPage.todoItems).toHaveCount(1);

--- a/playwright/tests/todomvc.spec.js
+++ b/playwright/tests/todomvc.spec.js
@@ -1,0 +1,67 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('todo mvc', () => {
+    test.describe('basic', () => {
+    // Basic tests
+    // Add a new todo item
+    // Mark a todo as complete
+    // Delete a todo item
+        test.beforeEach(async ({ page }) => {
+            await page.goto('https://todomvc.com/examples/react/dist/');
+            await expect(page.url()).toContain('react');
+            await expect(page.locator('h1')).toContainText('todos');
+        });
+
+        test('add a new todo item', async ({ page }) => {
+            await page.getByTestId('text-input').fill('buy milk');
+            await page.getByTestId('text-input').press('Enter');
+            await expect(page.getByTestId('todo-item-label')).toHaveText('buy milk');
+            await expect(page.getByTestId('todo-item-label')).toHaveCount(1);
+        });
+
+        test('mark a todo as complete', async ({ page }) => {
+            await page.getByTestId('text-input').fill('buy milk');
+            await page.getByTestId('text-input').press('Enter');
+            await expect(page.getByTestId('todo-item-label')).toHaveCount(1);
+            await page.getByTestId('todo-item-toggle').click();
+            await expect(page.getByTestId('todo-item-label')).toHaveCount(1);
+            await expect(page.locator('.todo-count')).toHaveText('0 items left!');
+        });
+
+        test('delete a todo item', async ({ page }) => {
+            await page.getByTestId('text-input').fill('buy milk');
+            await page.getByTestId('text-input').press('Enter');
+            await expect(page.getByTestId('todo-item-label')).toHaveCount(1);
+            await page.getByTestId('todo-item-label').hover();
+            await expect(page.getByTestId('todo-item-button')).toBeVisible();
+            await page.getByTestId('todo-item-button').click();
+            await expect(page.getByTestId('todo-item-label')).toHaveCount(0);
+        });
+    });
+
+    test.describe('intermediate', () => {
+    // Intermediate tests
+    // Edit an existing todo
+    // Toggle all todos complete/incomplete
+    // Clear completed todos
+    // Verify todo count updates correctly
+    });
+
+    test.describe('advanced', () => {
+    // Advanced tests
+    // Verify todos persist after page reload (localStorage)
+    // Filter todos (All/Active/Completed)
+    // Add multiple todos and verify order
+    // Test with long text/special characters
+    // Test keyboard shortcuts (Enter to add, Esc to cancel edit)
+    });
+
+    test.describe('edge cases', () => {
+    // Edge cases
+    // Add empty todo (should not be allowed)
+    // Add whitespace-only todo
+    // Add very long todo text
+    // Handle duplicate todo items
+    });
+
+});

--- a/playwright/tests/todomvc.spec.js
+++ b/playwright/tests/todomvc.spec.js
@@ -98,21 +98,27 @@ test.describe('todo mvc', () => {
         })
     });
 
-    test.describe('advanced', () => {
-    // Advanced tests
-    // Verify todos persist after page reload (localStorage)
-    // Filter todos (All/Active/Completed)
-    // Add multiple todos and verify order
-    // Test with long text/special characters
-    // Test keyboard shortcuts (Enter to add, Esc to cancel edit)
-    });
-
     test.describe('edge cases', () => {
-    // Edge cases
-    // Add empty todo (should not be allowed)
-    // Add whitespace-only todo
-    // Add very long todo text
-    // Handle duplicate todo items
+        test('cannot create empty todo item', async () => {
+            await todoPage.addTodoItem('');
+            await expect(todoPage.todoItems).toHaveCount(0);
+        });
+
+        test('cannot create todo item with just spaces', async () => {
+            await todoPage.addTodoItem(' ');
+            await expect(todoPage.todoItems).toHaveCount(0);
+        });
+
+        test('can create duplicate todo items', async () => {
+            await todoPage.addTodoItem('buy eggs');
+            await todoPage.addTodoItem('buy eggs');
+            await expect(todoPage.todoItems).toHaveCount(2);
+
+            await todoPage.switchListTo('Active');
+            await todoPage.markTodoComplete('buy eggs');
+            await todoPage.markTodoComplete('buy eggs');
+            await expect(todoPage.todoItems).toHaveCount(0);
+        });
     });
 
 });

--- a/playwright/tests/todomvc.spec.js
+++ b/playwright/tests/todomvc.spec.js
@@ -46,7 +46,7 @@ test.describe('todo mvc', () => {
             await todoPage.editTodoItem('buy milk', 'buy eggs');
             await expect(todoPage.todoItems).toHaveText('buy eggs');
         });
-    // Toggle all todos complete/incomplete
+
         test('toggle between active and incomplete todos', async ({page}) => {
             await todoPage.addTodoItem('buy milk');
             await todoPage.addTodoItem('buy eggs');
@@ -64,9 +64,38 @@ test.describe('todo mvc', () => {
 
             await todoPage.switchListTo('All');
             await expect(todoPage.todoItems).toHaveCount(3);
+        });
+
+        test('clear completed todo items', async ({page}) => {
+            await todoPage.addTodoItem('buy milk');
+            await todoPage.addTodoItem('buy eggs');
+            await todoPage.addTodoItem('buy butter');
+            await expect(todoPage.todoItems).toHaveCount(3);
+
+            await expect(todoPage.clearCompletedButton).toBeDisabled();
+
+            await todoPage.markTodoComplete('buy eggs');
+            await todoPage.markTodoComplete('buy butter');
+
+            await todoPage.clearCompletedTodoItems();
+            await expect(todoPage.todoItems).toHaveCount(1);
+        });
+
+        test('verify todo count summary is updated', async ({page}) => {
+            await expect(todoPage.todoCountSummary).not.toBeVisible();
+
+            await todoPage.addTodoItem('buy milk');
+            await expect(todoPage.todoCountSummary).toHaveText('1 item left!');
+            await todoPage.addTodoItem('buy eggs');
+            await todoPage.addTodoItem('buy butter');
+            await expect(todoPage.todoItems).toHaveCount(3);
+            await expect(todoPage.todoCountSummary).toHaveText('3 items left!');
+
+            await todoPage.markTodoComplete('buy milk');
+            await todoPage.markTodoComplete('buy eggs');
+            await todoPage.markTodoComplete('buy butter');
+            await expect(todoPage.todoCountSummary).toHaveText('0 items left!');
         })
-    // Clear completed todos
-    // Verify todo count updates correctly
     });
 
     test.describe('advanced', () => {

--- a/playwright/tests/todomvc.spec.js
+++ b/playwright/tests/todomvc.spec.js
@@ -1,26 +1,27 @@
 const { test, expect } = require('@playwright/test');
 const TodoPage = require('./pages/TodoPage');
+const { todo } = require('node:test');
 
 test.describe('todo mvc', () => {
-    test.describe('basic', () => {
-        let todoPage;
-        test.beforeEach(async ({ page }) => {
-            todoPage = new TodoPage(page);
-            await todoPage.goto();
-            await expect(page.url()).toContain('react');
-            await expect(page.locator('h1')).toContainText('todos');
-            await expect(page.getByTestId('todo-item-label')).toHaveCount(0);
-        });
+    let todoPage;
+    test.beforeEach(async ({ page }) => {
+        todoPage = new TodoPage(page);
+        await todoPage.goto();
+        await expect(page.url()).toContain('react');
+        await expect(page.locator('h1')).toContainText('todos');
+        await expect(page.getByTestId('todo-item-label')).toHaveCount(0);
+    });
 
+    test.describe('basic', () => {
         test('add a new todo item', async ({ page }) => {
-            await todoPage.addTodo('buy milk');
+            await todoPage.addTodoItem('buy milk');
 
             await expect(todoPage.todoItems).toHaveText('buy milk');
             await expect(todoPage.todoItems).toHaveCount(1);
         });
 
-        test.only('mark a todo as complete', async ({ page }) => {
-            await todoPage.addTodo('buy milk');
+        test('mark a todo as complete', async ({ page }) => {
+            await todoPage.addTodoItem('buy milk');
             await expect(todoPage.todoItems).toHaveCount(1);
             await todoPage.markTodoComplete('buy milk');
 
@@ -29,7 +30,7 @@ test.describe('todo mvc', () => {
         });
 
         test.skip('delete a todo item', async ({ page }) => {
-            await todoPage.addTodo('buy milk');
+            await todoPage.addTodoItem('buy milk');
             await expect(todoPage.todoItems).toHaveCount(1);
             await todoPage.deleteTodoItem('buy milk');
 
@@ -40,6 +41,13 @@ test.describe('todo mvc', () => {
     test.describe('intermediate', () => {
     // Intermediate tests
     // Edit an existing todo
+        test('edit a todo item', async ({page}) => {
+            await todoPage.addTodoItem('buy milk');
+            await expect(todoPage.todoItems).toHaveCount(1);
+
+            await todoPage.editTodoItem('buy milk', 'buy eggs');
+            await expect(todoPage.todoItems).toHaveText('buy eggs');
+        });
     // Toggle all todos complete/incomplete
     // Clear completed todos
     // Verify todo count updates correctly

--- a/playwright/tests/todomvc.spec.js
+++ b/playwright/tests/todomvc.spec.js
@@ -1,41 +1,39 @@
 const { test, expect } = require('@playwright/test');
+const TodoPage = require('./pages/TodoPage');
 
 test.describe('todo mvc', () => {
     test.describe('basic', () => {
-    // Basic tests
-    // Add a new todo item
-    // Mark a todo as complete
-    // Delete a todo item
+        let todoPage;
         test.beforeEach(async ({ page }) => {
-            await page.goto('https://todomvc.com/examples/react/dist/');
+            todoPage = new TodoPage(page);
+            await todoPage.goto();
             await expect(page.url()).toContain('react');
             await expect(page.locator('h1')).toContainText('todos');
+            await expect(page.getByTestId('todo-item-label')).toHaveCount(0);
         });
 
         test('add a new todo item', async ({ page }) => {
-            await page.getByTestId('text-input').fill('buy milk');
-            await page.getByTestId('text-input').press('Enter');
-            await expect(page.getByTestId('todo-item-label')).toHaveText('buy milk');
-            await expect(page.getByTestId('todo-item-label')).toHaveCount(1);
+            await todoPage.addTodo('buy milk');
+
+            await expect(todoPage.todoItems).toHaveText('buy milk');
+            await expect(todoPage.todoItems).toHaveCount(1);
         });
 
-        test('mark a todo as complete', async ({ page }) => {
-            await page.getByTestId('text-input').fill('buy milk');
-            await page.getByTestId('text-input').press('Enter');
-            await expect(page.getByTestId('todo-item-label')).toHaveCount(1);
-            await page.getByTestId('todo-item-toggle').click();
-            await expect(page.getByTestId('todo-item-label')).toHaveCount(1);
-            await expect(page.locator('.todo-count')).toHaveText('0 items left!');
+        test.only('mark a todo as complete', async ({ page }) => {
+            await todoPage.addTodo('buy milk');
+            await expect(todoPage.todoItems).toHaveCount(1);
+            await todoPage.markTodoComplete('buy milk');
+
+            await expect(todoPage.todoItems).toHaveText('buy milk');
+            await expect(todoPage.todoItems).toHaveCount(1);
         });
 
-        test('delete a todo item', async ({ page }) => {
-            await page.getByTestId('text-input').fill('buy milk');
-            await page.getByTestId('text-input').press('Enter');
-            await expect(page.getByTestId('todo-item-label')).toHaveCount(1);
-            await page.getByTestId('todo-item-label').hover();
-            await expect(page.getByTestId('todo-item-button')).toBeVisible();
-            await page.getByTestId('todo-item-button').click();
-            await expect(page.getByTestId('todo-item-label')).toHaveCount(0);
+        test.skip('delete a todo item', async ({ page }) => {
+            await todoPage.addTodo('buy milk');
+            await expect(todoPage.todoItems).toHaveCount(1);
+            await todoPage.deleteTodoItem('buy milk');
+
+            await expect(todoPage.todoItems).toHaveCount(0);
         });
     });
 

--- a/playwright/tests/todomvc.spec.js
+++ b/playwright/tests/todomvc.spec.js
@@ -1,6 +1,5 @@
 const { test, expect } = require('@playwright/test');
 const TodoPage = require('./pages/TodoPage');
-const { todo } = require('node:test');
 
 test.describe('todo mvc', () => {
     let todoPage;
@@ -20,13 +19,16 @@ test.describe('todo mvc', () => {
             await expect(todoPage.todoItems).toHaveCount(1);
         });
 
-        test('mark a todo as complete', async ({ page }) => {
+        test.only('mark a todo as complete', async ({ page }) => {
             await todoPage.addTodoItem('buy milk');
             await expect(todoPage.todoItems).toHaveCount(1);
-            await todoPage.markTodoComplete('buy milk');
 
+
+            await todoPage.markTodoComplete('buy milk');
             await expect(todoPage.todoItems).toHaveText('buy milk');
             await expect(todoPage.todoItems).toHaveCount(1);
+            await expect(todoPage.getCompletedTodoItem('buy milk')).toHaveText('buy milk');
+            await expect(todoPage.getCompletedTodoItem('buy milk')).toHaveCSS('text-decoration', /line-through/);
         });
 
         test.skip('delete a todo item', async ({ page }) => {

--- a/playwright/tests/todomvc.spec.js
+++ b/playwright/tests/todomvc.spec.js
@@ -39,8 +39,6 @@ test.describe('todo mvc', () => {
     });
 
     test.describe('intermediate', () => {
-    // Intermediate tests
-    // Edit an existing todo
         test('edit a todo item', async ({page}) => {
             await todoPage.addTodoItem('buy milk');
             await expect(todoPage.todoItems).toHaveCount(1);
@@ -49,6 +47,24 @@ test.describe('todo mvc', () => {
             await expect(todoPage.todoItems).toHaveText('buy eggs');
         });
     // Toggle all todos complete/incomplete
+        test('toggle between active and incomplete todos', async ({page}) => {
+            await todoPage.addTodoItem('buy milk');
+            await todoPage.addTodoItem('buy eggs');
+            await todoPage.addTodoItem('buy butter');
+            await expect(todoPage.todoItems).toHaveCount(3);
+
+            await todoPage.markTodoComplete('buy eggs');
+            await todoPage.switchListTo('Active');
+            await expect(todoPage.todoItems.filter({ hasText: 'buy eggs' })).toHaveCount(0);
+            await expect(todoPage.todoItems).toHaveCount(2);
+
+            await todoPage.switchListTo('Completed');
+            await expect(todoPage.todoItems).toHaveText('buy eggs');
+            await expect(todoPage.todoItems).toHaveCount(1);
+
+            await todoPage.switchListTo('All');
+            await expect(todoPage.todoItems).toHaveCount(3);
+        })
     // Clear completed todos
     // Verify todo count updates correctly
     });


### PR DESCRIPTION
* Adds tests for todo mvc app
* Adds page object model

note: deleting todo has issues because hovering over an `nth` item seems to not work, so skipping that for now

```
$ npx playwright test tests/todomvc.spec.js

Running 10 tests using 4 workers

  -  1 [chromium] › todomvc.spec.js:32:14 › todo mvc › basic › delete a todo item
  ✓  2 [chromium] › todomvc.spec.js:50:9 › todo mvc › intermediate › toggle between active and incomplete todos (975ms)
  ✓  3 [chromium] › todomvc.spec.js:42:9 › todo mvc › intermediate › edit a todo item (755ms)
  ✓  4 [chromium] › todomvc.spec.js:23:9 › todo mvc › basic › mark a todo as complete (777ms)
  ✓  5 [chromium] › todomvc.spec.js:16:9 › todo mvc › basic › add a new todo item (645ms)
  ✓  6 [chromium] › todomvc.spec.js:69:9 › todo mvc › intermediate › clear completed todo items (722ms)
  ✓  7 [chromium] › todomvc.spec.js:84:9 › todo mvc › intermediate › verify todo count summary is updated (632ms)
  ✓  8 [chromium] › todomvc.spec.js:102:9 › todo mvc › edge cases › cannot create empty todo item (287ms)
  ✓  9 [chromium] › todomvc.spec.js:107:9 › todo mvc › edge cases › cannot create todo item with just spaces (334ms)
  ✓  10 [chromium] › todomvc.spec.js:112:9 › todo mvc › edge cases › can create duplicate todo items (454ms)

  1 skipped
  9 passed (2.3s)
  ```